### PR TITLE
テストによるバグの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,4 +11,11 @@ class ApplicationController < ActionController::Base
         redirect_to login_url, status: :see_other
       end
     end
+
+    # すでにログインしているユーザーのリダイレクト
+    def already_logged_in
+      if logged_in?
+        redirect_to root_url, status: :see_other
+      end
+    end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  before_action :already_logged_in, only: [:new]
 
   def new
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy,
+  before_action :logged_in_user, only: [:index, :show, :edit, :update, :destroy,
                                         :following, :followers]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
                     uniqueness: true
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
+  validate :password_confirmation_without_password
 
   # 渡された文字列のハッシュ値を返す
   def User.digest(string)
@@ -119,6 +120,13 @@ class User < ApplicationRecord
     def create_activation_digest
       self.activation_token  = User.new_token
       self.activation_digest = User.digest(activation_token)
+    end
+
+    # パスワード確認のみ入力された場合のバリデーション
+    def password_confirmation_without_password
+      if password_confirmation.present? && password.blank?
+        errors.add(:password, "can't be blank if password confirmation is provided")
+      end
     end
 
 end


### PR DESCRIPTION
バグ詳細リンク
https://github.com/yama-shoki/rails-sample-app/issues/36#issuecomment-3264852107

スプレッドシート
https://docs.google.com/spreadsheets/d/12mE_j3SQKekCp2A_xPH8g6T5UWLwmEkNyT2BVhlcYTA/edit?gid=745497740#gid=745497740&range=B8:D9

- ①ログイン中に /login にアクセスできる
→ バグ。ログイン中に/loginにアクセスすると、「/」にリダイレクトするように修正。
app/controllers/application_controller.rbにログイン時のリダイレクトを追加。
```ruby
 # すでにログインしているユーザーのリダイレクト
    def already_logged_in
      if logged_in?
        redirect_to root_url, status: :see_other
      end
    end
```



- ②ログアウト中に /users/{id}にアクセスできる
→ バグ。ログアウト中に/users/{id}にアクセスすると、「/login」にリダイレクトするように修正。
ログアウト時のページアクセスを制限
app/controllers/users_controller.rb
```ruby
 before_action :logged_in_user, only: [:index, :show, :edit, :update, :destroy,
```


- ③settingsページのpasswordのバリデーションが発火しない。Confirmationのみで更新メッセージが表示される。
→Confirmationのみ入力は、実際にはパスワードの更新は行われていない。nameとemailの更新が優先されてしまい、更新メッセージが表示される。パスワードのバリデーションを追加して対応。
app/models/user.rb
```ruby
has_secure_password
  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
  validate :password_confirmation_without_password #バリデーション追加


# パスワード確認のみ入力された場合のバリデーション
    def password_confirmation_without_password
      if password_confirmation.present? && password.blank?
        errors.add(:password, "can't be blank if password confirmation is provided")
      end
    end
```
Fixes #39